### PR TITLE
Allow turning off route registration in the ServiceProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ https://laravel.com/pragmarx/countries/flag/file/usa.svg
 
 http://pragmarx.test/pragmarx/countries/flag/file/usa.svg
 
+These routes can be turned off in the configuration file:
+
+```php
+'routes' => [
+    'enabled' => false,
+]
+```
+
 ## Author
 
 [Antonio Carlos Ribeiro](http://twitter.com/iantonioribeiro)

--- a/src/config/countries.php
+++ b/src/config/countries.php
@@ -36,6 +36,10 @@ return [
         'currencies' => 'currency',
     ],
 
+    'routes' => [
+        'enabled' => true,
+    ],
+
     'validation' => [
         'enabled' => true,
         'rules' => [

--- a/src/package/ServiceProvider.php
+++ b/src/package/ServiceProvider.php
@@ -82,7 +82,9 @@ class ServiceProvider extends IlluminateServiceProvider
 
         $this->registerUpdateCommand();
 
-        $this->registerRoutes();
+        if (config('countries.routes.enabled')) {
+            $this->registerRoutes();
+        }
     }
 
     /**


### PR DESCRIPTION
I didn't want to have the routes automatically registered in my application, so I added a config flag in order to turn them off (still enabled by default, so no breaking changes).

Tested locally with the new config both on and off as well as with the previous config and the default of being on is present.