### PR TITLE
Update dependencies to make it compatible with Laravel9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
 # - nightly
 
 env:
@@ -21,7 +20,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.2" || "$TRAVIS_PHP_VERSION" == "nightly" ]] || phpenv config-rm xdebug.ini'
+  - '[[ "$TRAVIS_PHP_VERSION" == "8.0" || "$TRAVIS_PHP_VERSION" == "nightly" ]] || phpenv config-rm xdebug.ini'
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
@@ -30,7 +29,7 @@ script:
 
 after_script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == '7.2' ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == '8.0' ]]; then
       wget https://scrutinizer-ci.com/ocular.phar
       php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi

--- a/composer.json
+++ b/composer.json
@@ -27,20 +27,45 @@
         }
     ],
 
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/coollection"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/countries"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/ia-arr"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/ia-str"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/ia-collection"
+        }
+    ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.3",
-        "psr/simple-cache": "^1.0",
-        "pragmarx/coollection": ">=0.6",
-        "pragmarx/countries": ">=0.5.8"
+        "illuminate/support": ">=5.3",
+        "psr/simple-cache": "^1.0|^2.0|^3.0",
+        "pragmarx/coollection": "dev-update-ia-collection",
+        "pragmarx/ia-arr": "dev-update-var-dumper",
+        "pragmarx/ia-str": "dev-update-portable-ascii",
+        "pragmarx/ia-collection": "dev-update-var-dumper",
+        "pragmarx/countries": "dev-update-pragmarx-coollection"
     },
 
     "require-dev": {
-        "orchestra/testbench": "~3.0|~4.0|~5.0",
+        "orchestra/testbench": "~3.0|~4.0|~5.0|~6.0|~7.0",
         "phpunit/phpunit": "~6.0|~7.0|~8.0|~9.0",
-        "squizlabs/php_codesniffer": "^2.3",
-        "colinodell/json5": "^1.0",
-        "gasparesganga/php-shapefile": "^2.3"
+        "squizlabs/php_codesniffer": "^2.3|^3.6",
+        "colinodell/json5": "^1.0|^2.0",
+        "gasparesganga/php-shapefile": "^2.3|^3.4"
     },
 
     "autoload": {


### PR DESCRIPTION
## Description

Update `psr/simple-cache`, `pragmarx/countries` and `pragmarx/coollection` dependencies.
Also remove `composer.lock` and update travis config file.

## Motivation and context

Laravel 9.x requires `symfony/var-dumper` ^6.0  and `voku/portable-ascii` ^2.0.
This is part of some updates on multiple `pragmarx` packages which aren't compatible with Laravel9 yet, this helps fixing that.

See
- https://github.com/antonioribeiro/countries/pull/193
- https://github.com/antonioribeiro/coollection/pull/14
- https://github.com/antonioribeiro/ia-str/pull/5
- https://github.com/antonioribeiro/ia-collection/pull/11
- https://github.com/antonioribeiro/ia-arr/pull/4
